### PR TITLE
add django as a requirement, pin to 1.11 for now

### DIFF
--- a/pyme-depends/meta.yaml
+++ b/pyme-depends/meta.yaml
@@ -170,6 +170,7 @@ requirements:
     - sphinx
     - ujson
     - jinja2
+    - django 1.11
     - dispatch
     - pycairo
     - pymecompress >=0.1.4


### PR DESCRIPTION
see python-microscopy issue [#160](https://github.com/python-microscopy/python-microscopy/issues/160), working towards migrating to cluster of one