### PR TITLE
Pin scipy to temporarily address miscoordination with fftpack

### DIFF
--- a/pyme-depends/meta.yaml
+++ b/pyme-depends/meta.yaml
@@ -128,7 +128,7 @@ requirements:
   run:
     - python {{ python }}
     - numpy >= 1.4
-    - scipy <= 1.3
+    - scipy
     - matplotlib
     - wxpython <= 4.0.4
     #<3.9 [py2k] #FIXME - there are still some issues with display logic on wx=4.x

--- a/pyme-depends/meta.yaml
+++ b/pyme-depends/meta.yaml
@@ -128,7 +128,7 @@ requirements:
   run:
     - python {{ python }}
     - numpy >= 1.4
-    - scipy
+    - scipy <= 1.3
     - matplotlib
     - wxpython <= 4.0.4
     #<3.9 [py2k] #FIXME - there are still some issues with display logic on wx=4.x


### PR DESCRIPTION
Address issue with https://github.com/python-microscopy/python-microscopy/issues/268. Still a problem with a fresh install. Pinning for now will solve this.