### PR TITLE
fix whitespace to accomodate conda-bld synthax

### DIFF
--- a/pyme-depends/meta.yaml
+++ b/pyme-depends/meta.yaml
@@ -127,7 +127,7 @@ requirements:
   # in requirements" below).
   run:
     - python {{ python }}
-    - numpy >=1.4
+    - numpy >=1.14
     - scipy
     - matplotlib
     - wxpython <=4.0.4

--- a/pyme-depends/meta.yaml
+++ b/pyme-depends/meta.yaml
@@ -127,16 +127,16 @@ requirements:
   # in requirements" below).
   run:
     - python {{ python }}
-    - numpy >= 1.4
+    - numpy >=1.4
     - scipy
     - matplotlib
-    - wxpython <= 4.0.4
+    - wxpython <=4.0.4
     #<3.9 [py2k] #FIXME - there are still some issues with display logic on wx=4.x
     #- wxpython-phoenix < 3.9 [py3k]
     #- wxpython [py3k] #FIXME - there are still some issues with display logic on wx=4.x
     - pytables # <=3.4.2 #seems like the version pinning may no longer be needed ... fingers crossed
     - pyopengl
-    - traits <= 5.1.1
+    - traits <=5.1.1
     - traitsui
     - pillow
 


### PR DESCRIPTION
saw it first for numpy, though 'that's weird', followed the suggestion (see below for wx) then found that conda build synthax is just a bit weird with the space.
https://github.com/conda/conda-build/issues/2117
```
(base) ubuntu@stromberg:~/code/pyme-conda-recipes$ conda build pyme-depends
No numpy version specified in conda_build_config.yaml.  Falling back to default numpy value of 1.11
WARNING:conda_build.metadata:No numpy version specified in conda_build_config.yaml.  Falling back to default numpy value of 1.11
Adding in variants from internal_defaults
INFO:conda_build.variants:Adding in variants from internal_defaults
Adding in variants from /home/ubuntu/code/pyme-conda-recipes/pyme-depends/conda_build_config.yaml
INFO:conda_build.variants:Adding in variants from /home/ubuntu/code/pyme-conda-recipes/pyme-depends/conda_build_config.yaml
Error: bad character '<=' in package version dependency 'wxpython'
Perhaps you meant 'wxpython <=4.0.4'

```