### PR TITLE
update noarch_python to noarch for conda build > 2017

### DIFF
--- a/toposort/meta.yaml
+++ b/toposort/meta.yaml
@@ -1,17 +1,17 @@
 package:
   name: toposort
-  version: "1.1"
+  version: "1.5"
 
 source:
-  fn: toposort-1.1.tar.gz
-  url: https://pypi.python.org/packages/source/t/toposort/toposort-1.1.tar.gz
-  md5: 87c0d8de376953997eb092ca150064d8
+  fn: toposort-1.5.tar.gz
+  url: https://pypi.python.org/packages/source/t/toposort/toposort-1.5.tar.gz
+  md5: 472cf86871d19b66d7cb18412c026959
 #  patches:
    # List any patch files here
    # - fix.patch
 
 build:
-  noarch_python: False
+  noarch: False
   # preserve_egg_dir: True
   # entry_points:
     # Put any entry points (scripts to be generated automatically) here. The


### PR DESCRIPTION
The `noarch_python` has been [deprecated](https://www.anaconda.com/blog/condas-new-noarch-packages), and if you build with later versions of conda build the prelink will fail when you try to install the package

<details><summary> traceback </summary>

```
>conda create -n nepfitting -c barentine nep-fitting=1.08
Collecting package metadata (current_repodata.json): done
Solving environment: failed with repodata from current_repodata.json, will retry with next repodata source.
Collecting package metadata (repodata.json): done
Solving environment: done

## Package Plan ##

  environment location: C:\Users\Bergamot\Anaconda2\envs\bld\envs\nepfitting

  added / updated specs:
    - nep-fitting=1.08


The following packages will be downloaded:

    package                    |            build
    ---------------------------|-----------------
    alabaster-0.7.12           |           py36_0          18 KB
    babel-2.8.0                |             py_0         5.3 MB
    blosc-1.19.0               |       h7bd577a_0         141 KB
    brotlipy-0.7.0             |py36he774522_1000         337 KB
    bzip2-1.0.8                |       he774522_0         113 KB
    cairo-1.14.12              |       hf171d8a_3         2.5 MB
    cffi-1.14.0                |   py36h7a1dbc1_0         222 KB
    chardet-3.0.4              |        py36_1003         197 KB
    cheroot-8.3.0              |           py36_0         150 KB
    cherrypy-18.6.0            |           py36_0         547 KB
    cloudpickle-1.5.0          |             py_0          22 KB
    cryptography-2.9.2         |   py36h7a1dbc1_0         523 KB
    cytoolz-0.10.1             |   py36he774522_0         303 KB
    dask-core-2.20.0           |             py_0         590 KB
    dispatch-1.0               |           py36_0          19 KB  david_baddeley
    docutils-0.16              |           py36_1         664 KB
    fftw-3.3.4                 |                0         2.2 MB  david_baddeley
    future-0.18.2              |           py36_1         647 KB
    hdf5-1.10.4                |       h7ebc959_0         7.9 MB
    idna-2.10                  |             py_0          50 KB
    ifaddr-0.1.6               |             py_0           9 KB  david_baddeley
    imageio-2.9.0              |             py_0         3.0 MB
    imagesize-1.2.0            |             py_0          10 KB
    importlib_resources-1.4.0  |           py36_0          32 KB
    jaraco.classes-3.1.0       |             py_0          11 KB
    jaraco.collections-3.0.0   |             py_0          13 KB
    jaraco.functools-3.0.1     |             py_0          11 KB
    jaraco.text-3.2.0          |           py36_0          16 KB
    jinja2-2.11.2              |             py_0         103 KB
    joblib-0.16.0              |             py_0         210 KB
    libtiff-4.1.0              |       h56a325e_1         739 KB
    lz4-c-1.9.2                |       h62dcd97_0         230 KB
    lzo-2.10                   |       he774522_2         142 KB
    markupsafe-1.1.1           |   py36he774522_0          31 KB
    mock-4.0.2                 |             py_0          32 KB
    more-itertools-8.4.0       |             py_0          42 KB
    mpld3-v0.3                 |           py36_0         127 KB  david_baddeley
    nep-fitting-1.8            |           py36_0         447 KB  barentine
    networkx-2.4               |             py_1         1.1 MB
    numexpr-2.7.1              |   py36h25d0782_0         126 KB
    olefile-0.46               |           py36_0          49 KB
    openssl-1.1.1g             |       he774522_0         4.8 MB
    packaging-20.4             |             py_0          36 KB
    pandas-1.0.5               |   py36h47e9c7a_0         6.9 MB
    pillow-7.2.0               |   py36hcc1f983_0         663 KB
    pixman-0.40.0              |       he774522_0         404 KB
    portend-2.5                |             py_0          10 KB
    psutil-5.7.0               |   py36he774522_0         340 KB
    pycairo-1.19.1             |   py36h63da52a_0          80 KB
    pycparser-2.20             |             py_2          94 KB
    pyface-7.0.1               |           py36_1         1.0 MB
    pyfftw-v0.11.1             |   py36h39e3cac_0         2.0 MB  david_baddeley
    pygments-2.6.1             |             py_0         654 KB
    pyme-depends-1.08          |           py36_0           5 KB  barentine
    pymecompress-0.2.0         |           py36_0         387 KB  barentine
    pyopengl-3.1.1a1           |           py36_0         1.0 MB
    pyopenssl-19.1.0           |             py_1          48 KB
    pysocks-1.7.1              |           py36_0          31 KB
    pytables-3.6.1             |   py36h1da0976_0         2.2 MB
    python-microscopy-20.04.25 |           py36_0         3.9 MB  barentine
    pytz-2020.1                |             py_0         184 KB
    pywavelets-1.1.1           |   py36he774522_0         3.4 MB
    pywin32-227                |   py36he774522_1         5.6 MB
    pyyaml-5.3.1               |   py36he774522_1         154 KB
    qt-5.9.7                   |   vc14h73c81de_0        72.5 MB
    repoze.lru-0.7             |           py36_0          22 KB
    requests-2.24.0            |             py_0          56 KB
    routes-2.4.1               |             py_1          36 KB
    scikit-image-0.16.2        |   py36h47e9c7a_0        22.6 MB
    scikit-learn-0.23.1        |   py36h25d0782_0         4.6 MB
    scipy-1.5.0                |   py36h9439919_0        11.8 MB
    simplejson-3.17.0          |   py36he774522_0         105 KB
    snappy-1.1.8               |       h33f27b4_0          80 KB
    snowballstemmer-2.0.0      |             py_0          62 KB
    sphinx-3.1.2               |             py_0         1.1 MB
    sphinxcontrib-applehelp-1.0.2|             py_0          27 KB
    sphinxcontrib-devhelp-1.0.2|             py_0          22 KB
    sphinxcontrib-htmlhelp-1.0.3|             py_0          27 KB
    sphinxcontrib-jsmath-1.0.1 |             py_0           9 KB
    sphinxcontrib-qthelp-1.0.3 |             py_0          25 KB
    sphinxcontrib-serializinghtml-1.1.4|             py_0          24 KB
    tempora-3.0.0              |             py_0          19 KB
    threadpoolctl-2.1.0        |     pyh5ca1d4c_0          17 KB
    tk-8.6.10                  |       he774522_0         2.7 MB
    toolz-0.10.0               |             py_0          52 KB
    toposort-1.1               |     pyh0993448_1           8 KB  david_baddeley
    traits-6.1.0               |   py36he774522_0         581 KB
    traitsui-7.0.1             |             py_0         456 KB
    ujson-3.0.0                |   py36ha925a31_0          49 KB
    urllib3-1.25.9             |             py_0         103 KB
    win_inet_pton-1.1.0        |           py36_0           9 KB
    wxpython-4.0.4             |   py36ha925a31_0        11.3 MB
    xz-5.2.5                   |       h62dcd97_0         244 KB
    yaml-0.2.5                 |       he774522_0          62 KB
    zc.lockfile-2.0            |             py_0          12 KB
    zeroconf-0.24.0            |           py36_3          66 KB  david_baddeley
    zstd-1.4.5                 |       ha9fde0e_0         455 KB
    ------------------------------------------------------------
                                           Total:       192.0 MB

The following NEW packages will be INSTALLED:

  alabaster          pkgs/main/win-64::alabaster-0.7.12-py36_0
  babel              pkgs/main/noarch::babel-2.8.0-py_0
  blas               pkgs/main/win-64::blas-1.0-mkl
  blosc              pkgs/main/win-64::blosc-1.19.0-h7bd577a_0
  brotlipy           pkgs/main/win-64::brotlipy-0.7.0-py36he774522_1000
  bzip2              pkgs/main/win-64::bzip2-1.0.8-he774522_0
  ca-certificates    pkgs/main/win-64::ca-certificates-2020.6.24-0
  cairo              pkgs/main/win-64::cairo-1.14.12-hf171d8a_3
  certifi            pkgs/main/win-64::certifi-2020.6.20-py36_0
  cffi               pkgs/main/win-64::cffi-1.14.0-py36h7a1dbc1_0
  chardet            pkgs/main/win-64::chardet-3.0.4-py36_1003
  cheroot            pkgs/main/win-64::cheroot-8.3.0-py36_0
  cherrypy           pkgs/main/win-64::cherrypy-18.6.0-py36_0
  cloudpickle        pkgs/main/noarch::cloudpickle-1.5.0-py_0
  cryptography       pkgs/main/win-64::cryptography-2.9.2-py36h7a1dbc1_0
  cycler             pkgs/main/win-64::cycler-0.10.0-py36h009560c_0
  cython             pkgs/main/win-64::cython-0.29.21-py36ha925a31_0
  cytoolz            pkgs/main/win-64::cytoolz-0.10.1-py36he774522_0
  dask-core          pkgs/main/noarch::dask-core-2.20.0-py_0
  decorator          pkgs/main/noarch::decorator-4.4.2-py_0
  dispatch           david_baddeley/win-64::dispatch-1.0-py36_0
  docutils           pkgs/main/win-64::docutils-0.16-py36_1
  fftw               david_baddeley/win-64::fftw-3.3.4-0
  freetype           pkgs/main/win-64::freetype-2.10.2-hd328e21_0
  future             pkgs/main/win-64::future-0.18.2-py36_1
  hdf5               pkgs/main/win-64::hdf5-1.10.4-h7ebc959_0
  icc_rt             pkgs/main/win-64::icc_rt-2019.0.0-h0cc432a_1
  icu                pkgs/main/win-64::icu-58.2-ha925a31_3
  idna               pkgs/main/noarch::idna-2.10-py_0
  ifaddr             david_baddeley/noarch::ifaddr-0.1.6-py_0
  imageio            pkgs/main/noarch::imageio-2.9.0-py_0
  imagesize          pkgs/main/noarch::imagesize-1.2.0-py_0
  importlib-metadata pkgs/main/win-64::importlib-metadata-1.7.0-py36_0
  importlib_metadata pkgs/main/noarch::importlib_metadata-1.7.0-0
  importlib_resourc~ pkgs/main/win-64::importlib_resources-1.4.0-py36_0
  intel-openmp       pkgs/main/win-64::intel-openmp-2020.1-216
  jaraco.classes     pkgs/main/noarch::jaraco.classes-3.1.0-py_0
  jaraco.collections pkgs/main/noarch::jaraco.collections-3.0.0-py_0
  jaraco.functools   pkgs/main/noarch::jaraco.functools-3.0.1-py_0
  jaraco.text        pkgs/main/win-64::jaraco.text-3.2.0-py36_0
  jinja2             pkgs/main/noarch::jinja2-2.11.2-py_0
  joblib             pkgs/main/noarch::joblib-0.16.0-py_0
  jpeg               pkgs/main/win-64::jpeg-9b-hb83a4c4_2
  kiwisolver         pkgs/main/win-64::kiwisolver-1.2.0-py36h74a9793_0
  libpng             pkgs/main/win-64::libpng-1.6.37-h2a8f88b_0
  libtiff            pkgs/main/win-64::libtiff-4.1.0-h56a325e_1
  lz4-c              pkgs/main/win-64::lz4-c-1.9.2-h62dcd97_0
  lzo                pkgs/main/win-64::lzo-2.10-he774522_2
  markupsafe         pkgs/main/win-64::markupsafe-1.1.1-py36he774522_0
  matplotlib         pkgs/main/win-64::matplotlib-3.2.2-0
  matplotlib-base    pkgs/main/win-64::matplotlib-base-3.2.2-py36h64f37c6_0
  mkl                pkgs/main/win-64::mkl-2020.1-216
  mkl-service        pkgs/main/win-64::mkl-service-2.3.0-py36hb782905_0
  mkl_fft            pkgs/main/win-64::mkl_fft-1.1.0-py36h45dec08_0
  mkl_random         pkgs/main/win-64::mkl_random-1.1.1-py36h47e9c7a_0
  mock               pkgs/main/noarch::mock-4.0.2-py_0
  more-itertools     pkgs/main/noarch::more-itertools-8.4.0-py_0
  mpld3              david_baddeley/win-64::mpld3-v0.3-py36_0
  nep-fitting        barentine/win-64::nep-fitting-1.8-py36_0
  networkx           pkgs/main/noarch::networkx-2.4-py_1
  numexpr            pkgs/main/win-64::numexpr-2.7.1-py36h25d0782_0
  numpy              pkgs/main/win-64::numpy-1.18.5-py36h6530119_0
  numpy-base         pkgs/main/win-64::numpy-base-1.18.5-py36hc3f5095_0
  olefile            pkgs/main/win-64::olefile-0.46-py36_0
  openssl            pkgs/main/win-64::openssl-1.1.1g-he774522_0
  packaging          pkgs/main/noarch::packaging-20.4-py_0
  pandas             pkgs/main/win-64::pandas-1.0.5-py36h47e9c7a_0
  pillow             pkgs/main/win-64::pillow-7.2.0-py36hcc1f983_0
  pip                pkgs/main/win-64::pip-20.1.1-py36_1
  pixman             pkgs/main/win-64::pixman-0.40.0-he774522_0
  portend            pkgs/main/noarch::portend-2.5-py_0
  psutil             pkgs/main/win-64::psutil-5.7.0-py36he774522_0
  pycairo            pkgs/main/win-64::pycairo-1.19.1-py36h63da52a_0
  pycparser          pkgs/main/noarch::pycparser-2.20-py_2
  pyface             pkgs/main/win-64::pyface-7.0.1-py36_1
  pyfftw             david_baddeley/win-64::pyfftw-v0.11.1-py36h39e3cac_0
  pygments           pkgs/main/noarch::pygments-2.6.1-py_0
  pyme-depends       barentine/win-64::pyme-depends-1.08-py36_0
  pymecompress       barentine/win-64::pymecompress-0.2.0-py36_0
  pyopengl           pkgs/main/win-64::pyopengl-3.1.1a1-py36_0
  pyopenssl          pkgs/main/noarch::pyopenssl-19.1.0-py_1
  pyparsing          pkgs/main/noarch::pyparsing-2.4.7-py_0
  pyqt               pkgs/main/win-64::pyqt-5.9.2-py36h6538335_2
  pysocks            pkgs/main/win-64::pysocks-1.7.1-py36_0
  pytables           pkgs/main/win-64::pytables-3.6.1-py36h1da0976_0
  python             pkgs/main/win-64::python-3.6.10-h9f7ef89_2
  python-dateutil    pkgs/main/noarch::python-dateutil-2.8.1-py_0
  python-microscopy  barentine/win-64::python-microscopy-20.04.25-py36_0
  pytz               pkgs/main/noarch::pytz-2020.1-py_0
  pywavelets         pkgs/main/win-64::pywavelets-1.1.1-py36he774522_0
  pywin32            pkgs/main/win-64::pywin32-227-py36he774522_1
  pyyaml             pkgs/main/win-64::pyyaml-5.3.1-py36he774522_1
  qt                 pkgs/main/win-64::qt-5.9.7-vc14h73c81de_0
  repoze.lru         pkgs/main/win-64::repoze.lru-0.7-py36_0
  requests           pkgs/main/noarch::requests-2.24.0-py_0
  routes             pkgs/main/noarch::routes-2.4.1-py_1
  scikit-image       pkgs/main/win-64::scikit-image-0.16.2-py36h47e9c7a_0
  scikit-learn       pkgs/main/win-64::scikit-learn-0.23.1-py36h25d0782_0
  scipy              pkgs/main/win-64::scipy-1.5.0-py36h9439919_0
  setuptools         pkgs/main/win-64::setuptools-49.2.0-py36_0
  simplejson         pkgs/main/win-64::simplejson-3.17.0-py36he774522_0
  sip                pkgs/main/win-64::sip-4.19.8-py36h6538335_0
  six                pkgs/main/noarch::six-1.15.0-py_0
  snappy             pkgs/main/win-64::snappy-1.1.8-h33f27b4_0
  snowballstemmer    pkgs/main/noarch::snowballstemmer-2.0.0-py_0
  sphinx             pkgs/main/noarch::sphinx-3.1.2-py_0
  sphinxcontrib-app~ pkgs/main/noarch::sphinxcontrib-applehelp-1.0.2-py_0
  sphinxcontrib-dev~ pkgs/main/noarch::sphinxcontrib-devhelp-1.0.2-py_0
  sphinxcontrib-htm~ pkgs/main/noarch::sphinxcontrib-htmlhelp-1.0.3-py_0
  sphinxcontrib-jsm~ pkgs/main/noarch::sphinxcontrib-jsmath-1.0.1-py_0
  sphinxcontrib-qth~ pkgs/main/noarch::sphinxcontrib-qthelp-1.0.3-py_0
  sphinxcontrib-ser~ pkgs/main/noarch::sphinxcontrib-serializinghtml-1.1.4-py_0
  sqlite             pkgs/main/win-64::sqlite-3.32.3-h2a8f88b_0
  tempora            pkgs/main/noarch::tempora-3.0.0-py_0
  threadpoolctl      pkgs/main/noarch::threadpoolctl-2.1.0-pyh5ca1d4c_0
  tk                 pkgs/main/win-64::tk-8.6.10-he774522_0
  toolz              pkgs/main/noarch::toolz-0.10.0-py_0
  toposort           david_baddeley/noarch::toposort-1.1-pyh0993448_1
  tornado            pkgs/main/win-64::tornado-6.0.4-py36he774522_1
  traits             pkgs/main/win-64::traits-6.1.0-py36he774522_0
  traitsui           pkgs/main/noarch::traitsui-7.0.1-py_0
  ujson              pkgs/main/win-64::ujson-3.0.0-py36ha925a31_0
  urllib3            pkgs/main/noarch::urllib3-1.25.9-py_0
  vc                 pkgs/main/win-64::vc-14.1-h0510ff6_4
  vs2015_runtime     pkgs/main/win-64::vs2015_runtime-14.16.27012-hf0eaf9b_3
  wheel              pkgs/main/win-64::wheel-0.34.2-py36_0
  win_inet_pton      pkgs/main/win-64::win_inet_pton-1.1.0-py36_0
  wincertstore       pkgs/main/win-64::wincertstore-0.2-py36h7fe50ca_0
  wxpython           pkgs/main/win-64::wxpython-4.0.4-py36ha925a31_0
  xz                 pkgs/main/win-64::xz-5.2.5-h62dcd97_0
  yaml               pkgs/main/win-64::yaml-0.2.5-he774522_0
  zc.lockfile        pkgs/main/noarch::zc.lockfile-2.0-py_0
  zeroconf           david_baddeley/win-64::zeroconf-0.24.0-py36_3
  zipp               pkgs/main/noarch::zipp-3.1.0-py_0
  zlib               pkgs/main/win-64::zlib-1.2.11-h62dcd97_4
  zstd               pkgs/main/win-64::zstd-1.4.5-ha9fde0e_0


Proceed ([y]/n)? y


Downloading and Extracting Packages
sphinxcontrib-qthelp | 25 KB     | ######################################################################### | 100%
pillow-7.2.0         | 663 KB    | ######################################################################### | 100%
python-microscopy-20 | 3.9 MB    | ######################################################################### | 100%
traits-6.1.0         | 581 KB    | ######################################################################### | 100%
win_inet_pton-1.1.0  | 9 KB      | ######################################################################### | 100%
sphinxcontrib-serial | 24 KB     | ######################################################################### | 100%
blosc-1.19.0         | 141 KB    | ######################################################################### | 100%
packaging-20.4       | 36 KB     | ######################################################################### | 100%
bzip2-1.0.8          | 113 KB    | ######################################################################### | 100%
scikit-learn-0.23.1  | 4.6 MB    | ######################################################################### | 100%
snappy-1.1.8         | 80 KB     | ######################################################################### | 100%
lzo-2.10             | 142 KB    | ######################################################################### | 100%
cffi-1.14.0          | 222 KB    | ######################################################################### | 100%
idna-2.10            | 50 KB     | ######################################################################### | 100%
numexpr-2.7.1        | 126 KB    | ######################################################################### | 100%
pyme-depends-1.08    | 5 KB      | ######################################################################### | 100%
importlib_resources- | 32 KB     | ######################################################################### | 100%
pymecompress-0.2.0   | 387 KB    | ######################################################################### | 100%
zeroconf-0.24.0      | 66 KB     | ######################################################################### | 100%
zstd-1.4.5           | 455 KB    | ######################################################################### | 100%
chardet-3.0.4        | 197 KB    | ######################################################################### | 100%
cytoolz-0.10.1       | 303 KB    | ######################################################################### | 100%
babel-2.8.0          | 5.3 MB    | ######################################################################### | 100%
routes-2.4.1         | 36 KB     | ######################################################################### | 100%
tk-8.6.10            | 2.7 MB    | ######################################################################### | 100%
snowballstemmer-2.0. | 62 KB     | ######################################################################### | 100%
sphinxcontrib-appleh | 27 KB     | ######################################################################### | 100%
nep-fitting-1.8      | 447 KB    | ######################################################################### | 100%
cairo-1.14.12        | 2.5 MB    | ######################################################################### | 100%
traitsui-7.0.1       | 456 KB    | ######################################################################### | 100%
pyyaml-5.3.1         | 154 KB    | ######################################################################### | 100%
pyopengl-3.1.1a1     | 1.0 MB    | ######################################################################### | 100%
pytz-2020.1          | 184 KB    | ######################################################################### | 100%
cheroot-8.3.0        | 150 KB    | ######################################################################### | 100%
pytables-3.6.1       | 2.2 MB    | ######################################################################### | 100%
threadpoolctl-2.1.0  | 17 KB     | ######################################################################### | 100%
ifaddr-0.1.6         | 9 KB      | ######################################################################### | 100%
brotlipy-0.7.0       | 337 KB    | ######################################################################### | 100%
pyface-7.0.1         | 1.0 MB    | ######################################################################### | 100%
imageio-2.9.0        | 3.0 MB    | ######################################################################### | 100%
lz4-c-1.9.2          | 230 KB    | ######################################################################### | 100%
openssl-1.1.1g       | 4.8 MB    | ######################################################################### | 100%
urllib3-1.25.9       | 103 KB    | ######################################################################### | 100%
qt-5.9.7             | 72.5 MB   | ######################################################################### | 100%
pixman-0.40.0        | 404 KB    | ######################################################################### | 100%
pyopenssl-19.1.0     | 48 KB     | ######################################################################### | 100%
cloudpickle-1.5.0    | 22 KB     | ######################################################################### | 100%
jaraco.collections-3 | 13 KB     | ######################################################################### | 100%
wxpython-4.0.4       | 11.3 MB   | ######################################################################### | 100%
jinja2-2.11.2        | 103 KB    | ######################################################################### | 100%
mock-4.0.2           | 32 KB     | ######################################################################### | 100%
xz-5.2.5             | 244 KB    | ######################################################################### | 100%
hdf5-1.10.4          | 7.9 MB    | ######################################################################### | 100%
pycparser-2.20       | 94 KB     | ######################################################################### | 100%
jaraco.text-3.2.0    | 16 KB     | ######################################################################### | 100%
tempora-3.0.0        | 19 KB     | ######################################################################### | 100%
cryptography-2.9.2   | 523 KB    | ######################################################################### | 100%
dask-core-2.20.0     | 590 KB    | ######################################################################### | 100%
jaraco.functools-3.0 | 11 KB     | ######################################################################### | 100%
pyfftw-v0.11.1       | 2.0 MB    | ######################################################################### | 100%
olefile-0.46         | 49 KB     | ######################################################################### | 100%
jaraco.classes-3.1.0 | 11 KB     | ######################################################################### | 100%
more-itertools-8.4.0 | 42 KB     | ######################################################################### | 100%
repoze.lru-0.7       | 22 KB     | ######################################################################### | 100%
pygments-2.6.1       | 654 KB    | ######################################################################### | 100%
fftw-3.3.4           | 2.2 MB    | ######################################################################### | 100%
zc.lockfile-2.0      | 12 KB     | ######################################################################### | 100%
docutils-0.16        | 664 KB    | ######################################################################### | 100%
yaml-0.2.5           | 62 KB     | ######################################################################### | 100%
pywin32-227          | 5.6 MB    | ######################################################################### | 100%
cherrypy-18.6.0      | 547 KB    | ######################################################################### | 100%
toposort-1.1         | 8 KB      | ######################################################################### | 100%
libtiff-4.1.0        | 739 KB    | ######################################################################### | 100%
alabaster-0.7.12     | 18 KB     | ######################################################################### | 100%
simplejson-3.17.0    | 105 KB    | ######################################################################### | 100%
pandas-1.0.5         | 6.9 MB    | ######################################################################### | 100%
toolz-0.10.0         | 52 KB     | ######################################################################### | 100%
sphinxcontrib-jsmath | 9 KB      | ######################################################################### | 100%
portend-2.5          | 10 KB     | ######################################################################### | 100%
sphinx-3.1.2         | 1.1 MB    | ######################################################################### | 100%
mpld3-v0.3           | 127 KB    | ######################################################################### | 100%
sphinxcontrib-htmlhe | 27 KB     | ######################################################################### | 100%
markupsafe-1.1.1     | 31 KB     | ######################################################################### | 100%
pycairo-1.19.1       | 80 KB     | ######################################################################### | 100%
ujson-3.0.0          | 49 KB     | ######################################################################### | 100%
dispatch-1.0         | 19 KB     | ######################################################################### | 100%
pysocks-1.7.1        | 31 KB     | ######################################################################### | 100%
scipy-1.5.0          | 11.8 MB   | ######################################################################### | 100%
sphinxcontrib-devhel | 22 KB     | ######################################################################### | 100%
requests-2.24.0      | 56 KB     | ######################################################################### | 100%
networkx-2.4         | 1.1 MB    | ######################################################################### | 100%
psutil-5.7.0         | 340 KB    | ######################################################################### | 100%
joblib-0.16.0        | 210 KB    | ######################################################################### | 100%
imagesize-1.2.0      | 10 KB     | ######################################################################### | 100%
pywavelets-1.1.1     | 3.4 MB    | ######################################################################### | 100%
scikit-image-0.16.2  | 22.6 MB   | ######################################################################### | 100%
future-0.18.2        | 647 KB    | ######################################################################### | 100%
Preparing transaction: done
Verifying transaction: done
Executing transaction: | C:\Users\Bergamot\Anaconda2\envs\bld\lib\site-packages\conda\core\link.py:1144: UserWarning: Package david_baddeley::toposort-1.1-pyh0993448_1 uses a pre-link script. Pre-link scripts are potentially dangerous.
This is because pre-link scripts have the ability to change the package contents in the
package cache, and therefore modify the underlying files for already-created conda
environments.  Future versions of conda may deprecate and ignore pre-link scripts.

  """) % prec.dist_str())
failed

LinkError: pre-link script failed for package david_baddeley::toposort-1.1-pyh0993448_1
location of failed script: C:\Users\Bergamot\Anaconda2\envs\bld\pkgs\toposort-1.1-pyh0993448_1\Scripts\.toposort-pre-link.bat
==> script messages <==
<None>
==> script output <==
stdout:
stderr: '"C:\Users\Bergamot\Anaconda2\envs\bld\envs\nepfitting\python.exe"' is not recognized as an internal or external command,
operable program or batch file.

return code: 1



```

</details>


Also update to 1.5 (effectively no code updates between 1.1 and 1.5, just packaging) as David currently has for osx in his conda channel.