### PR TITLE
sync names / launchers with python-microscopy/conda-recs 

### DIFF
--- a/python-microscopy/menu-windows.json
+++ b/python-microscopy/menu-windows.json
@@ -12,21 +12,27 @@
                 "quicklaunch": true
             },
             {
-                "script": "${PREFIX}/Scripts/dh5view.exe",
+                "script": "${PREFIX}/Scripts/PYMEClusterOfOne.exe",
                 "scriptarguments": [],
-
-                "name": "dh5view",
+                "name": "PYMEClusterOfOne",
                 "workdir": "${USERPROFILE}",
                 "icon": "${MENU_DIR}/pmanal.ico",
                 "desktop": true,
                 "quicklaunch": true
             },
-
+            {
+                "script": "${PREFIX}/Scripts/dh5view.exe",
+                "scriptarguments": [],
+                "name": "PYMEImage (dh5view)",
+                "workdir": "${USERPROFILE}",
+                "icon": "${MENU_DIR}/pmanal.ico",
+                "desktop": true,
+                "quicklaunch": true
+            },
              {
                 "script": "${PREFIX}/Scripts/VisGUI.exe",
                 "scriptarguments": [],
-
-                "name": "VisGUI",
+                "name": "PYMEVisualize (VisGUI)",
                 "workdir": "${USERPROFILE}",
                 "icon": "${MENU_DIR}/pmvis.ico",
                 "desktop": true,
@@ -35,7 +41,6 @@
             {
                 "script": "${PREFIX}/Scripts/bakeshop.exe",
                 "scriptarguments": [],
-
                 "name": "Bakeshop",
                 "workdir": "${USERPROFILE}",
                 "icon": "${MENU_DIR}/pmanal.ico",
@@ -52,6 +57,5 @@
               "scriptarguments": ["/K", "${ROOT_PREFIX}\\Scripts\\activate.bat", "${PREFIX}"],
               "icon": "${MENU_DIR}/Iconleak-Atrous-Console.ico"
             }
-
         ]
 }


### PR DESCRIPTION
As requested. Copy-paste from python-microscopy/conda-recipes/python-microscopy/...

- adds cluster of one to launch menu/desktop
- leaves launchWorkers in for now
- updates PYMEVisualize and PYMEImage names