### PR TITLE
pin zeroconf version even on py3 until we update

### DIFF
--- a/pyme-depends/meta.yaml
+++ b/pyme-depends/meta.yaml
@@ -166,7 +166,7 @@ requirements:
     - shapely [osx and py2k]
 
     - zeroconf 0.17.7 [py2k]
-    - zeroconf [py3k] #this might be too permissive
+    - zeroconf <=0.26.3 [py3k]
     - requests
     - pandas
     - pyyaml


### PR DESCRIPTION
current PYME codebase is incompatible with zeroconf > 0.26.3 because in 0.27 zeroconf removed the previously deprecated ServiceInfo address constructor which we use. 

current pyme-depends ships broken as it installs 0.28

py2 support was dropped on 0.20, and when we can boot that we should consider bumping everything to 0.28