### PR TITLE
FIx pyme-deps-strict

### DIFF
--- a/pyme-depends-strict/meta.yaml
+++ b/pyme-depends-strict/meta.yaml
@@ -154,7 +154,7 @@ requirements:
     # - pyro [py2k]
 
     # - pyfftw3 [py2k]
-    - pyfftw ==0.11.1 #[py3k]
+    - pyfftw ==v0.11.1 #[py3k]
 
     - mpld3 ==0.5.1
     - python.app ==2     [osx]
@@ -190,7 +190,7 @@ requirements:
     - alabaster ==0.7.12
     - babel ==2.9.0
     - backports ==1.0
-    - backports.lzma ==0.014
+    - backports.lzma ==0.0.14
     - blas ==1.0
     - brotlipy ==0.7.0
     - bzip2 ==1.0.8
@@ -207,7 +207,7 @@ requirements:
     - cycler ==0.10.0
     - cytoolz ==0.11.0
     - dask-core ==2.30.0
-    - dbus ==1.13.8 [osx]
+    - dbus ==1.13.18 [osx]
     - decorator ==4.4.2
     - expat ==2.2.10 [osx]
     - fftw ==3.3.8
@@ -225,7 +225,7 @@ requirements:
     - importlib-metadata ==2.0.0
     - importlib_metadata ==2.0.0
     - importlib_resources ==3.3.0
-    - intel-openmp ==2020.2 [win] # hardware-specific? definitely linked to mkl
+    - intel-openmp ==2020.2  # hardware-specific? definitely linked to mkl
     - intel-openmp ==2019.4 [osx] # hardware-specific? definitely linked to mkl
     - jaraco.classes ==3.1.0  # do we need this?
     - jaraco.collections ==3.0.0  # do we need this?
@@ -243,13 +243,13 @@ requirements:
     - libpng ==1.6.37
     - libtiff ==4.1.0
     - libxml2 ==2.9.10 [osx]
-    - llvm-openmp == 10.0.0 [osx]
+    - llvm-openmp ==10.0.0 [osx]
     - lz4-c ==1.9.2
     - lzo ==2.10
     - markupsafe ==1.1.1
     - matplotlib-base ==3.2.2  # do we need this?
-    - menuinst ==1.14.6
-    - mkl ==2020.2
+    - menuinst ==1.14.6 [win]
+    - mkl ==2020.2 [win]
     - mkl ==2019.4 [osx]
     - mkl-service ==2.3.0
     - mkl_fft ==1.2.0


### PR DESCRIPTION
Still can't quite test it since I can't seem to turn off superseding, but it builds now.

```
The following packages will be SUPERSEDED by a higher-priority channel:

  pyme-depends          conda-bld::pyme-depends-1.13-py36_0 --> david_baddeley::pyme-depends-1.08-py36_0

```