### PR TITLE
Make python-javabridge/python-bioformats builds work

### DIFF
--- a/python-bioformats/meta.yaml
+++ b/python-bioformats/meta.yaml
@@ -32,14 +32,14 @@ requirements:
     - setuptools
     - boto3 >=1.14.23
     - future >=0.18.2
-    - python-javabridge 4.0.0
+    - python-javabridge ==4.0.0
 
   run:
     - python
     # - openjdk
     - boto3 >=1.14.23
     - future >=0.18.2
-    - python-javabridge 4.0.0
+    - python-javabridge ==4.0.0
 
 test:
   # Python imports, fine to import javabridge and bioformats w/o the python- in front

--- a/python-javabridge/bld.bat
+++ b/python-javabridge/bld.bat
@@ -1,6 +1,9 @@
 set MSSdk=1
 set DISTUTILS_USE_SDK=1
 
+:: JAVA_HOME is set by openjdk install
+set JDK_HOME=%LIBRARY_PREFIX%
+
 "%PYTHON%" setup.py install
 if errorlevel 1 exit 1
 

--- a/python-javabridge/build.sh
+++ b/python-javabridge/build.sh
@@ -5,6 +5,9 @@ if [ -n "$OSX_ARCH" ]
         export CFLAGS='-Wno-implicit-function-declaration'
 fi
 
+# JAVA_HOME is set by openjdk install
+export JDK_HOME=$LIBRARY_PREFIX
+
 $PYTHON setup.py install
 # Add more build steps here, if they are necessary.
 

--- a/python-javabridge/meta.yaml
+++ b/python-javabridge/meta.yaml
@@ -12,7 +12,7 @@ requirements:
     - python
     - setuptools
     - cython
-    - numpy
+    - numpy >=1.18.2
     - openjdk
 
   run:

--- a/python-javabridge/meta.yaml
+++ b/python-javabridge/meta.yaml
@@ -17,7 +17,7 @@ requirements:
 
   run:
     - python
-    - numpy
+    - numpy >=1.18.2
     - openjdk
 
 test:


### PR DESCRIPTION
Needed to add a `numpy` pin and point out `JDK_HOME` for `javabridge`. Test packages for mac and win10 at

https://anaconda.org/zacsimile/python-javabridge
https://anaconda.org/zacsimile/python-bioformats